### PR TITLE
Return an HTTPException with the problem message, instead of just 'In…

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -7,6 +7,8 @@ from diffusers import PNDMScheduler
 from PIL import Image
 from cog import BasePredictor, Input, Path
 
+from fastapi import HTTPException
+
 from image_to_image import (
     StableDiffusionImg2ImgPipeline,
     preprocess_init_image,
@@ -97,7 +99,7 @@ class Predictor(BasePredictor):
             num_inference_steps=num_inference_steps,
         )
         if any(output["nsfw_content_detected"]):
-            raise Exception("NSFW content detected, please try a different prompt")
+            raise HTTPException(status_code=500, detail="NSFW content detected, please try a different prompt")
 
         output_paths = []
         for i, sample in enumerate(output["sample"]):


### PR DESCRIPTION
Hi, just a suggestion for a minor change. This helps the REST API users understand what the problem was with their prompt.

Return an HTTPException with the problem message, instead of just 'Internal Server Error'

Thanks!